### PR TITLE
BUG: Fix failure using HD-BETv2

### DIFF
--- a/HDBrainExtractionTool/HDBrainExtractionTool.py
+++ b/HDBrainExtractionTool/HDBrainExtractionTool.py
@@ -282,14 +282,15 @@ class HDBrainExtractionToolLogic(ScriptedLoadableModuleLogic):
       tempFolder = slicer.util.tempDirectory()
       import SampleData
       dataLogic = SampleData.SampleDataLogic()
-      hdBetZipFilePath = dataLogic.downloadFile('https://github.com/MIC-DKFZ/HD-BET/archive/refs/heads/master.zip', tempFolder, 'HD-BET.zip')
+      ref = "0dcab33233e991b9f7a7cb33052b164eb50062bd"  # v1.1
+      hdBetZipFilePath = dataLogic.downloadFile(f'https://github.com/MIC-DKFZ/HD-BET/archive/{ref}.zip', tempFolder, 'HD-BET.zip')
       # Unzip file
       slicer.util.extractArchive(hdBetZipFilePath, tempFolder)
       # Copy HD_BET subfolder to this module's folder so that it can be found as a Python package
       import shutil
       import os
       scriptedModulesPath = os.path.dirname(slicer.util.modulePath(self.moduleName))
-      shutil.move(tempFolder+"/HD-BET-master/HD_BET", scriptedModulesPath+"/HD_BET")
+      shutil.move(tempFolder + f"/HD-BET-{ref}/HD_BET", scriptedModulesPath+"/HD_BET")
       import HD_BET
 
     # Ensure that the download folder for model files exist


### PR DESCRIPTION
This closes #2.

This change makes sure to download HD-BET 1.1 rather than a 2.0+ version which is currently incompatible with HDBrainExtractionTool.

cc: @lassoan 

## Compatibility issue with latest `main`:
![image](https://github.com/user-attachments/assets/d928028f-a667-4483-aeec-319dd298da48)

<details>
  <summary>SlicerHDBrainExtension python console output click here</summary>

```python
Python 3.9.10 (main, Jan 18 2025, 23:20:31) [MSC v.1939 64 bit (AMD64)] on win32
>>> 
Collecting light-the-torch>=0.5
  Downloading light_the_torch-0.8.0-py3-none-any.whl.metadata (9.3 kB)
Requirement already satisfied: pip<24.4,>=22.3 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from light-the-torch>=0.5) (24.0)
Downloading light_the_torch-0.8.0-py3-none-any.whl (14 kB)
Installing collected packages: light-the-torch
Successfully installed light-the-torch-0.8.0
Collecting torch
  Downloading https://download.pytorch.org/whl/cu124/torch-2.5.1%2Bcu124-cp39-cp39-win_amd64.whl (2510.7 MB)
     ---------------------------------------- 2.5/2.5 GB 1.8 MB/s eta 0:00:00
Collecting torchvision
  Downloading https://download.pytorch.org/whl/torchvision-0.2.0-py2.py3-none-any.whl (48 kB)
     ---------------------------------------- 48.8/48.8 kB 1.2 MB/s eta 0:00:00
Collecting filelock (from torch)
  Downloading https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl (11 kB)
Requirement already satisfied: typing-extensions>=4.8.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torch) (4.12.1)
Collecting networkx (from torch)
  Downloading https://download.pytorch.org/whl/networkx-3.2.1-py3-none-any.whl (1.6 MB)
     ---------------------------------------- 1.6/1.6 MB 21.0 MB/s eta 0:00:00
Collecting jinja2 (from torch)
  Downloading jinja2-3.1.5-py3-none-any.whl.metadata (2.6 kB)
Collecting fsspec (from torch)
  Downloading https://download.pytorch.org/whl/fsspec-2024.2.0-py3-none-any.whl (170 kB)
     ------------------------------------- 170.9/170.9 kB 10.7 MB/s eta 0:00:00
Collecting sympy==1.13.1 (from torch)
  Downloading https://download.pytorch.org/whl/sympy-1.13.1-py3-none-any.whl (6.2 MB)
     ---------------------------------------- 6.2/6.2 MB 11.6 MB/s eta 0:00:00
Collecting mpmath<1.4,>=1.1.0 (from sympy==1.13.1->torch)
  Downloading https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl (536 kB)
     ------------------------------------- 536.2/536.2 kB 11.2 MB/s eta 0:00:00
Requirement already satisfied: numpy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torchvision) (1.26.4)
Requirement already satisfied: pillow>=4.1.1 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torchvision) (10.3.0)
Requirement already satisfied: six in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torchvision) (1.16.0)
Collecting MarkupSafe>=2.0 (from jinja2->torch)
  Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl.metadata (4.1 kB)
Downloading jinja2-3.1.5-py3-none-any.whl (134 kB)
   ---------------------------------------- 134.6/134.6 kB 1.3 MB/s eta 0:00:00
Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl (15 kB)
Installing collected packages: mpmath, sympy, networkx, MarkupSafe, fsspec, filelock, jinja2, torch, torchvision
Successfully installed MarkupSafe-3.0.2 filelock-3.13.1 fsspec-2024.2.0 jinja2-3.1.5 mpmath-1.3.0 networkx-3.2.1 sympy-1.13.1 torch-2.5.1+cu124 torchvision-0.2.0
Collecting batchgenerators
  Downloading batchgenerators-0.25.1.tar.gz (76 kB)
     -------------------------------------- 77.0/77.0 kB 606.6 kB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: pillow>=7.1.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from batchgenerators) (10.3.0)
Requirement already satisfied: numpy>=1.10.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from batchgenerators) (1.26.4)
Requirement already satisfied: scipy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from batchgenerators) (1.13.1)
Collecting scikit-image (from batchgenerators)
  Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl.metadata (14 kB)
Collecting scikit-learn (from batchgenerators)
  Downloading scikit_learn-1.6.1-cp39-cp39-win_amd64.whl.metadata (15 kB)
Collecting future (from batchgenerators)
  Downloading future-1.0.0-py3-none-any.whl.metadata (4.0 kB)
Collecting pandas (from batchgenerators)
  Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl.metadata (19 kB)
Collecting unittest2 (from batchgenerators)
  Downloading unittest2-1.1.0-py2.py3-none-any.whl.metadata (15 kB)
Collecting threadpoolctl (from batchgenerators)
  Downloading threadpoolctl-3.5.0-py3-none-any.whl.metadata (13 kB)
Requirement already satisfied: python-dateutil>=2.8.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from pandas->batchgenerators) (2.9.0.post0)
Collecting pytz>=2020.1 (from pandas->batchgenerators)
  Downloading pytz-2024.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting tzdata>=2022.7 (from pandas->batchgenerators)
  Downloading tzdata-2024.2-py2.py3-none-any.whl.metadata (1.4 kB)
Requirement already satisfied: networkx>=2.8 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from scikit-image->batchgenerators) (3.2.1)
Collecting imageio>=2.33 (from scikit-image->batchgenerators)
  Downloading imageio-2.37.0-py3-none-any.whl.metadata (5.2 kB)
Collecting tifffile>=2022.8.12 (from scikit-image->batchgenerators)
  Downloading tifffile-2024.8.30-py3-none-any.whl.metadata (31 kB)
Requirement already satisfied: packaging>=21 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from scikit-image->batchgenerators) (24.0)
Collecting lazy-loader>=0.4 (from scikit-image->batchgenerators)
  Downloading lazy_loader-0.4-py3-none-any.whl.metadata (7.6 kB)
Collecting joblib>=1.2.0 (from scikit-learn->batchgenerators)
  Downloading joblib-1.4.2-py3-none-any.whl.metadata (5.4 kB)
Collecting argparse (from unittest2->batchgenerators)
  Downloading argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)
Requirement already satisfied: six>=1.4 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from unittest2->batchgenerators) (1.16.0)
Collecting traceback2 (from unittest2->batchgenerators)
  Downloading traceback2-1.4.0-py2.py3-none-any.whl.metadata (1.5 kB)
Collecting linecache2 (from traceback2->unittest2->batchgenerators)
  Downloading linecache2-1.0.0-py2.py3-none-any.whl.metadata (1000 bytes)
Downloading future-1.0.0-py3-none-any.whl (491 kB)
   ---------------------------------------- 491.3/491.3 kB 4.4 MB/s eta 0:00:00
Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl (11.6 MB)
   ---------------------------------------- 11.6/11.6 MB 4.8 MB/s eta 0:00:00
Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl (12.9 MB)
   ---------------------------------------- 12.9/12.9 MB 4.5 MB/s eta 0:00:00
Downloading scikit_learn-1.6.1-cp39-cp39-win_amd64.whl (11.2 MB)
   ---------------------------------------- 11.2/11.2 MB 4.9 MB/s eta 0:00:00
Downloading threadpoolctl-3.5.0-py3-none-any.whl (18 kB)
Downloading unittest2-1.1.0-py2.py3-none-any.whl (96 kB)
   ---------------------------------------- 96.4/96.4 kB 5.7 MB/s eta 0:00:00
Downloading imageio-2.37.0-py3-none-any.whl (315 kB)
   ---------------------------------------- 315.8/315.8 kB 3.9 MB/s eta 0:00:00
Downloading joblib-1.4.2-py3-none-any.whl (301 kB)
   ---------------------------------------- 301.8/301.8 kB 3.7 MB/s eta 0:00:00
Downloading lazy_loader-0.4-py3-none-any.whl (12 kB)
Downloading pytz-2024.2-py2.py3-none-any.whl (508 kB)
   ---------------------------------------- 508.0/508.0 kB 2.6 MB/s eta 0:00:00
Downloading tifffile-2024.8.30-py3-none-any.whl (227 kB)
   ---------------------------------------- 227.3/227.3 kB 4.6 MB/s eta 0:00:00
Downloading tzdata-2024.2-py2.py3-none-any.whl (346 kB)
   ---------------------------------------- 346.6/346.6 kB 3.1 MB/s eta 0:00:00
Downloading argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Downloading traceback2-1.4.0-py2.py3-none-any.whl (16 kB)
Downloading linecache2-1.0.0-py2.py3-none-any.whl (12 kB)
Building wheels for collected packages: batchgenerators
  Building wheel for batchgenerators (setup.py): started
  Building wheel for batchgenerators (setup.py): finished with status 'done'
  Created wheel for batchgenerators: filename=batchgenerators-0.25.1-py3-none-any.whl size=93102 sha256=ac669a629bfe6ba5eb90636319533472a8db2471786af1cad464328d0cda41f0
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\97\8d\b9\3a9435d619b6a4bcd98f8cb8b324da29b6173555bb80860bdd
Successfully built batchgenerators
Installing collected packages: pytz, linecache2, argparse, tzdata, traceback2, tifffile, threadpoolctl, lazy-loader, joblib, imageio, future, unittest2, scikit-learn, scikit-image, pandas, batchgenerators
Successfully installed argparse-1.4.0 batchgenerators-0.25.1 future-1.0.0 imageio-2.37.0 joblib-1.4.2 lazy-loader-0.4 linecache2-1.0.0 pandas-2.2.3 pytz-2024.2 scikit-image-0.24.0 scikit-learn-1.6.1 threadpoolctl-3.5.0 tifffile-2024.8.30 traceback2-1.4.0 tzdata-2024.2 unittest2-1.1.0
[Python] Failed to compute results.
[Python] No module named 'HD_BET.run'
Traceback (most recent call last):
  File "C:/Users/butlej30383/AppData/Local/slicer.org/Slicer 5.7.0-2025-01-18/slicer.org/Extensions-33194/HDBrainExtraction/lib/Slicer-5.7/qt-scripted-modules/HDBrainExtractionTool.py", line 237, in onApplyButton
    self.logic.process(self.ui.inputVolumeSelector.currentNode(), self.ui.outputVolumeSelector.currentNode(),
  File "C:/Users/butlej30383/AppData/Local/slicer.org/Slicer 5.7.0-2025-01-18/slicer.org/Extensions-33194/HDBrainExtraction/lib/Slicer-5.7/qt-scripted-modules/HDBrainExtractionTool.py", line 346, in process
    from HD_BET.run import run_hd_bet
ModuleNotFoundError: No module named 'HD_BET.run'
```
</details>

## This PR
![image](https://github.com/user-attachments/assets/0ee77bb7-c4f9-44ff-938c-21e4b73296d6)

<details>
  <summary>SlicerHDBrainExtension python console output click here</summary>

```python
Python 3.9.10 (main, Jan 18 2025, 23:20:31) [MSC v.1939 64 bit (AMD64)] on win32
>>> 
Collecting light-the-torch>=0.5
  Downloading light_the_torch-0.8.0-py3-none-any.whl.metadata (9.3 kB)
Requirement already satisfied: pip<24.4,>=22.3 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from light-the-torch>=0.5) (24.0)
Downloading light_the_torch-0.8.0-py3-none-any.whl (14 kB)
Installing collected packages: light-the-torch
Successfully installed light-the-torch-0.8.0
Collecting torch
  Downloading https://download.pytorch.org/whl/cu124/torch-2.5.1%2Bcu124-cp39-cp39-win_amd64.whl (2510.7 MB)
     ---------------------------------------- 2.5/2.5 GB 2.0 MB/s eta 0:00:00
Collecting torchvision
  Downloading https://download.pytorch.org/whl/torchvision-0.2.0-py2.py3-none-any.whl (48 kB)
     ---------------------------------------- 48.8/48.8 kB 2.6 MB/s eta 0:00:00
Collecting filelock (from torch)
  Downloading https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl (11 kB)
Requirement already satisfied: typing-extensions>=4.8.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torch) (4.12.1)
Collecting networkx (from torch)
  Downloading https://download.pytorch.org/whl/networkx-3.2.1-py3-none-any.whl (1.6 MB)
     ---------------------------------------- 1.6/1.6 MB 13.1 MB/s eta 0:00:00
Collecting jinja2 (from torch)
  Downloading jinja2-3.1.5-py3-none-any.whl.metadata (2.6 kB)
Collecting fsspec (from torch)
  Downloading https://download.pytorch.org/whl/fsspec-2024.2.0-py3-none-any.whl (170 kB)
     -------------------------------------- 170.9/170.9 kB 5.2 MB/s eta 0:00:00
Collecting sympy==1.13.1 (from torch)
  Downloading https://download.pytorch.org/whl/sympy-1.13.1-py3-none-any.whl (6.2 MB)
     ---------------------------------------- 6.2/6.2 MB 10.7 MB/s eta 0:00:00
Collecting mpmath<1.4,>=1.1.0 (from sympy==1.13.1->torch)
  Downloading https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl (536 kB)
     ------------------------------------- 536.2/536.2 kB 11.2 MB/s eta 0:00:00
Requirement already satisfied: numpy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torchvision) (1.26.4)
Requirement already satisfied: pillow>=4.1.1 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torchvision) (10.3.0)
Requirement already satisfied: six in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from torchvision) (1.16.0)
Collecting MarkupSafe>=2.0 (from jinja2->torch)
  Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl.metadata (4.1 kB)
Downloading jinja2-3.1.5-py3-none-any.whl (134 kB)
   ---------------------------------------- 134.6/134.6 kB 1.3 MB/s eta 0:00:00
Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl (15 kB)
Installing collected packages: mpmath, sympy, networkx, MarkupSafe, fsspec, filelock, jinja2, torch, torchvision
Successfully installed MarkupSafe-3.0.2 filelock-3.13.1 fsspec-2024.2.0 jinja2-3.1.5 mpmath-1.3.0 networkx-3.2.1 sympy-1.13.1 torch-2.5.1+cu124 torchvision-0.2.0
Collecting batchgenerators
  Downloading batchgenerators-0.25.1.tar.gz (76 kB)
     -------------------------------------- 77.0/77.0 kB 855.5 kB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: pillow>=7.1.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from batchgenerators) (10.3.0)
Requirement already satisfied: numpy>=1.10.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from batchgenerators) (1.26.4)
Requirement already satisfied: scipy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from batchgenerators) (1.13.1)
Collecting scikit-image (from batchgenerators)
  Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl.metadata (14 kB)
Collecting scikit-learn (from batchgenerators)
  Downloading scikit_learn-1.6.1-cp39-cp39-win_amd64.whl.metadata (15 kB)
Collecting future (from batchgenerators)
  Downloading future-1.0.0-py3-none-any.whl.metadata (4.0 kB)
Collecting pandas (from batchgenerators)
  Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl.metadata (19 kB)
Collecting unittest2 (from batchgenerators)
  Downloading unittest2-1.1.0-py2.py3-none-any.whl.metadata (15 kB)
Collecting threadpoolctl (from batchgenerators)
  Downloading threadpoolctl-3.5.0-py3-none-any.whl.metadata (13 kB)
Requirement already satisfied: python-dateutil>=2.8.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from pandas->batchgenerators) (2.9.0.post0)
Collecting pytz>=2020.1 (from pandas->batchgenerators)
  Downloading pytz-2024.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting tzdata>=2022.7 (from pandas->batchgenerators)
  Downloading tzdata-2024.2-py2.py3-none-any.whl.metadata (1.4 kB)
Requirement already satisfied: networkx>=2.8 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from scikit-image->batchgenerators) (3.2.1)
Collecting imageio>=2.33 (from scikit-image->batchgenerators)
  Downloading imageio-2.37.0-py3-none-any.whl.metadata (5.2 kB)
Collecting tifffile>=2022.8.12 (from scikit-image->batchgenerators)
  Downloading tifffile-2024.8.30-py3-none-any.whl.metadata (31 kB)
Requirement already satisfied: packaging>=21 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from scikit-image->batchgenerators) (24.0)
Collecting lazy-loader>=0.4 (from scikit-image->batchgenerators)
  Downloading lazy_loader-0.4-py3-none-any.whl.metadata (7.6 kB)
Collecting joblib>=1.2.0 (from scikit-learn->batchgenerators)
  Downloading joblib-1.4.2-py3-none-any.whl.metadata (5.4 kB)
Collecting argparse (from unittest2->batchgenerators)
  Downloading argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)
Requirement already satisfied: six>=1.4 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2025-01-18\lib\python\lib\site-packages (from unittest2->batchgenerators) (1.16.0)
Collecting traceback2 (from unittest2->batchgenerators)
  Downloading traceback2-1.4.0-py2.py3-none-any.whl.metadata (1.5 kB)
Collecting linecache2 (from traceback2->unittest2->batchgenerators)
  Downloading linecache2-1.0.0-py2.py3-none-any.whl.metadata (1000 bytes)
Downloading future-1.0.0-py3-none-any.whl (491 kB)
   ---------------------------------------- 491.3/491.3 kB 4.4 MB/s eta 0:00:00
Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl (11.6 MB)
   ---------------------------------------- 11.6/11.6 MB 3.8 MB/s eta 0:00:00
Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl (12.9 MB)
   ---------------------------------------- 12.9/12.9 MB 5.8 MB/s eta 0:00:00
Downloading scikit_learn-1.6.1-cp39-cp39-win_amd64.whl (11.2 MB)
   ---------------------------------------- 11.2/11.2 MB 4.1 MB/s eta 0:00:00
Downloading threadpoolctl-3.5.0-py3-none-any.whl (18 kB)
Downloading unittest2-1.1.0-py2.py3-none-any.whl (96 kB)
   ---------------------------------------- 96.4/96.4 kB 5.4 MB/s eta 0:00:00
Downloading imageio-2.37.0-py3-none-any.whl (315 kB)
   ---------------------------------------- 315.8/315.8 kB 9.9 MB/s eta 0:00:00
Downloading joblib-1.4.2-py3-none-any.whl (301 kB)
   ---------------------------------------- 301.8/301.8 kB 3.7 MB/s eta 0:00:00
Downloading lazy_loader-0.4-py3-none-any.whl (12 kB)
Downloading pytz-2024.2-py2.py3-none-any.whl (508 kB)
   ---------------------------------------- 508.0/508.0 kB 2.3 MB/s eta 0:00:00
Downloading tifffile-2024.8.30-py3-none-any.whl (227 kB)
   ---------------------------------------- 227.3/227.3 kB 3.5 MB/s eta 0:00:00
Downloading tzdata-2024.2-py2.py3-none-any.whl (346 kB)
   ---------------------------------------- 346.6/346.6 kB 5.4 MB/s eta 0:00:00
Downloading argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Downloading traceback2-1.4.0-py2.py3-none-any.whl (16 kB)
Downloading linecache2-1.0.0-py2.py3-none-any.whl (12 kB)
Building wheels for collected packages: batchgenerators
  Building wheel for batchgenerators (setup.py): started
  Building wheel for batchgenerators (setup.py): finished with status 'done'
  Created wheel for batchgenerators: filename=batchgenerators-0.25.1-py3-none-any.whl size=93102 sha256=173487c7a2601f9ae10cf6eb0b5d0a7af20e63cf261ee8bfdc9ec16dab8e407c
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\97\8d\b9\3a9435d619b6a4bcd98f8cb8b324da29b6173555bb80860bdd
Successfully built batchgenerators
Installing collected packages: pytz, linecache2, argparse, tzdata, traceback2, tifffile, threadpoolctl, lazy-loader, joblib, imageio, future, unittest2, scikit-learn, scikit-image, pandas, batchgenerators
Successfully installed argparse-1.4.0 batchgenerators-0.25.1 future-1.0.0 imageio-2.37.0 joblib-1.4.2 lazy-loader-0.4 linecache2-1.0.0 pandas-2.2.3 pytz-2024.2 scikit-image-0.24.0 scikit-learn-1.6.1 threadpoolctl-3.5.0 tifffile-2024.8.30 traceback2-1.4.0 tzdata-2024.2 unittest2-1.1.0
Downloading https://zenodo.org/record/2540695/files/0.model?download=1 ...
Downloading https://zenodo.org/record/2540695/files/1.model?download=1 ...
Downloading https://zenodo.org/record/2540695/files/2.model?download=1 ...
Downloading https://zenodo.org/record/2540695/files/3.model?download=1 ...
Downloading https://zenodo.org/record/2540695/files/4.model?download=1 ...
C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.7.0-2025-01-18\slicer.org\Extensions-33194\HDBrainExtraction\lib\Slicer-5.7\qt-scripted-modules\HD_BET\run.py:80: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  params.append(torch.load(p, map_location=lambda storage, loc: storage))
File: C:/Users/butlej30383/AppData/Local/Temp/Slicer/__SlicerTemp__2025-01-19_23+43+43.812/hdbet-input.nii.gz
preprocessing...
image shape after preprocessing:  (105, 160, 160)
prediction (CNN id)...
0
1
2
3
4
running postprocessing... 
exporting segmentation...

```
</details>